### PR TITLE
Intégration S7ack et Gamification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,43 @@
-# TrainingREST
+# Gamification engine
+*Le Groupe 7* has developped a REST API to help you gamify your application.  Here is how you can create your own gamification engine.
 
-# Start-up services
-## Running REST-API
+## Start-up services
+The following sections will tell you how to start and test your own gamification engine if you wish to expand it.
+
+### Running REST-API
+
 ```bash
 cd scripts
 ./runREST_API.sh
 ```
 
-## Running REST-API latest (from github registry)
+### Running REST-API latest (from github registry)
 ```bash
 cd scripts
 ./pullREST_API.sh
 ```
 
-## Test REST-API
+### Test REST-API
 ```bash
-cd scripts
-./testREST_API.sh
-```
-**Note**: for faster local testing (from 1m30 to 5s), you can `cd` into `/gamification-specs`, change the url of `pom.xml` (l22) from http://api:8080 to http://localhost:8080 then run `mvn clean test`. Because this url is used in the pipeline, please donc forget to change it back when pushing to master.
-
-# Build and run the Fruit microservice
-
-You can use maven to build and run the REST API implementation from the command line. After invoking the following maven goal, the Spring Boot server will be up and running, listening for connections on port 8080.
-
-```
-cd fruits-impl/
-mvn spring-boot:run
-```
-
-You can then access:
-
-* the [API documentation](http://localhost:8080/swagger-ui.html), generated from annotations in the code
-* the [API endpoint](http://localhost:8080/), accepting GET and POST requests
-
-You can use curl to invoke the endpoints:
-
-* To retrieve the list of fruits previously created:
-
-```
-curl -X GET --header 'Accept: application/json' 'http://localhost:8080/fruits'
-```
-
-* To create a new fruit (beware that in the live documentation, there are extra \ line separators in the JSON payload that cause issues in some shells)
-
-```
-curl -X POST --header 'Content-Type: application/json' --header 'Accept: */*' -d '{
-  "colour": "red",
-  "expirationDate": "2020-11-06",
-  "expirationDateTime": "2020-11-06T05:43:27.909Z",
-  "kind": "apple",
-  "size": "small",
-  "weight": "light"
-}' 'http://localhost:8080/fruits'
-```
-
-# Test the Fruit microservice by running the executable specification
-
-You can use the Cucumber project to validate the API implementation. Do this when the server is running.
-
-```
-cd cd fruits-specs/
+cd gamification-specs
 mvn clean test
 ```
-You will see the test results in the console, but you can also open the file located in `./target/cucumber`
+
+## Use the gamification engine for your application
+
+We provide several endpoints to help you gamify your application how you want it. We provide endpoints for:
+
+* badges
+* point-scales
+* leaderboards
+* rules
+
+When your application is being used, you can update the gamification engine about your users by posting requests to the endpoint:
+
+* events
+
+You can get information about your users by using the endpoint:
+
+* users
+
+You can find a complete documentation of the api >here<.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,131 @@
-# TrainingREST
+# S7ack - Gamification API
 
-# Start-up services
-## Running REST-API
-```bash
-cd scripts
-./runREST_API.sh
+*Etudiants : Bonzon Ludovic, Delhomme Claire, Mercado Pablo & Vaz Afonso Vitor*
+
+## Choix d'implémentation
+
+Utilisation d'une base de données MySQL dans les 2 projets
+
+...
+
+### Lien entre serveur S7ack et serveur de gamification
+
+// INSERT DIAGRAMME DE CLASSES HERE ???
+
+### Paliers et attribution points et badges au travers des règles
+
+// TODO : Vitor
+
+## Tests
+
+// TODO : Claire
+
+### Ce qui a été testé
+
+### Comment
+
+## État du projet
+
+Le projet est dans un état stable et fonctionnel. Des tests permettent d'évaluer le fonctionnement des différents
+composants, comme indiqué au point précédent.
+
+### Ce qui fonctionne
+
+Tous les endpoints tels que définis dans [la documentation d'API](http://localhost:8080/v3/api-docs) sont fonctionnels.
+
+La page de statistiques a été agrémentée de la présence de toutes les leaderboards relatifs à une point scale présents
+dans notre application
+
+// INSERT SCREENSHOT HERE
+
+La page de profil d'un utilisateur contient désormais en plus des statistiques globales sur le nombre de quesions posées
+et de réponses données, une section comportant tous les badges reçus suite aux actions effectuées sur le site et une
+section comportant le score dans chaque point scale où l'utilisateur possède des points.
+
+// INSERT SCREENSHOT HERE
+
+### Ce qui ne fonctionne pas
+
+- Nous n'avons pas implémenté de système de pagination pour les ressources obtenues au travers de l'API
+
+## Procédure d'exécution des projets en local
+
+### Données "démo" via scripts SQL
+
+Nous tenons à signaler que des scripts d'insertion de données "démo" sont présents et activés dans nos 2 projets par
+défaut. Ils prennent la forme de 2 scripts SQL de création base de données et d'insertions de données. Les scripts sont
+présents pour les 2 projets dans `docker/init/db` et sont copiés dans les fichiers `docker-compose` au moyen du
+paramètre suivant :
+
+```dockerfile 
+# in file: docker-compose.yml
+volumes:
+        - ./docker/init/db:/docker-entrypoint-initdb.d
 ```
 
-## Running REST-API latest (from github registry)
+Vous pouvez donc aisément désactiver ce paramètre pour ne pas insérer de données de démo.
+
+### Procédure de démarrage en local
+
+Concernant la procédure de démarrage des 2 applications, il faut simplement se rendre dans les dossiers `scripts/` de
+chaque projet, et lancer dans cet ordre :
+
+Pour le projet_2 (**Gamification API**) : `./runREST_API.sh`
+
+Pour le projet_1 (**S7ack**) : `./startDocker.sh`
+
+Une fois les scripts exécutés, patienter quelques instants pour s'assurer que tous les composants ont bien été démarrés.
+
+Puis se rendre sur [http://localhost:9080/stack/questions](http://localhost:9080/stack/questions) et profiter de
+l'application et de ses capacités de gamification !
+
+### Si vous n'utilisez pas les scripts d'insertion de données de démo
+
+#### API-Key dans `.env`
+
+Pour effectuer des requêtes vers l'API, il est nécessaire d'avoir enregistré l'application au moteur de gamification au
+moyen d'une requête `POST /applications` en fournissant un nom et une description de votre application. Ceci vous
+retournera une clé d'API unique qu'il sera nécessaire de placer dans le fichier contenant les variables
+d'environnement (pour S7ack c'est dans : `src/main/liberty/config/server.env`).
+
+#### Création manuelle de données
+
+Il faut penser à créer manuellement (via des requêtes curl ou via l'interface web swagger) des règles, point scales et
+badges, sinon tous les évènements créés à partir d'interaction avec S7ack n'auront aucun impact sur le côté gamifié de
+notre application.
+
+### Procédure de démarrage depuis GitHub Registry
+
+// TODO : Pablo
+
+### Running REST-API latest
+
 ```bash
 cd scripts
 ./pullREST_API.sh
 ```
 
-## Test REST-API
+### Test REST-API
+
 ```bash
 cd scripts
 ./testREST_API.sh
 ```
-**Note**: for faster local testing (from 1m30 to 5s), you can `cd` into `/gamification-specs`, change the url of `pom.xml` (l22) from http://api:8080 to http://localhost:8080 then run `mvn clean test`. Because this url is used in the pipeline, please donc forget to change it back when pushing to master.
 
-# Build and run the Fruit microservice
+**Note**: for faster local testing (from 1m30 to 5s), you can `cd` into `/gamification-specs`, change the url
+of `pom.xml` (l22) from http://api:8080 to http://localhost:8080 then run `mvn clean test`. Because this url is used in
+the pipeline, please donc forget to change it back when pushing to master.
 
-You can use maven to build and run the REST API implementation from the command line. After invoking the following maven goal, the Spring Boot server will be up and running, listening for connections on port 8080.
+## Problèmes rencontrés
+
+- Règles difficiles à mettre en place (pour prendre en compte les concepts de point scales, de badges et de paliers),
+  notamment en ce qui concerne le lien avec les évènements internes (lorsqu'un palier est franchi à la réception d'un
+  évènement, il faut pouvoir renvoyer un évènement pour traiter par exemple l'attribution d'un badge)
+
+## Build and run the Fruit microservice
+
+You can use maven to build and run the REST API implementation from the command line. After invoking the following maven
+goal, the Spring Boot server will be up and running, listening for connections on port 8080.
 
 ```
 cd fruits-impl/
@@ -42,7 +145,8 @@ You can use curl to invoke the endpoints:
 curl -X GET --header 'Accept: application/json' 'http://localhost:8080/fruits'
 ```
 
-* To create a new fruit (beware that in the live documentation, there are extra \ line separators in the JSON payload that cause issues in some shells)
+* To create a new fruit (beware that in the live documentation, there are extra \ line separators in the JSON payload
+  that cause issues in some shells)
 
 ```
 curl -X POST --header 'Content-Type: application/json' --header 'Accept: */*' -d '{
@@ -55,7 +159,7 @@ curl -X POST --header 'Content-Type: application/json' --header 'Accept: */*' -d
 }' 'http://localhost:8080/fruits'
 ```
 
-# Test the Fruit microservice by running the executable specification
+## Test the Fruit microservice by running the executable specification
 
 You can use the Cucumber project to validate the API implementation. Do this when the server is running.
 
@@ -63,4 +167,5 @@ You can use the Cucumber project to validate the API implementation. Do this whe
 cd cd fruits-specs/
 mvn clean test
 ```
+
 You will see the test results in the console, but you can also open the file located in `./target/cucumber`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
         - MYSQL_USER=amt-usr
         - MYSQL_ROOT_PASSWORD=amt-pw
         - MYSQL_PASSWORD=amt-pw
+      volumes:
+        - ./docker/init/db:/docker-entrypoint-initdb.d
       expose:
         - '3306'
       networks:

--- a/docker/init/db/gamification-dump-amt-db.sql
+++ b/docker/init/db/gamification-dump-amt-db.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: impl_db
--- Generation Time: Jan 08, 2021 at 03:24 PM
+-- Generation Time: Jan 16, 2021 at 05:15 PM
 -- Server version: 8.0.22
 -- PHP Version: 7.4.11
 
@@ -38,7 +38,9 @@ CREATE TABLE `application_entity` (
 --
 
 INSERT INTO `application_entity` (`id`, `api_key`, `name`) VALUES
-(1, 'eca8983f-c4c9-4093-a975-0a2178e130ef', 'Stack');
+(1, '84af416b-cf8f-4e4f-9b4c-37eb9209e4ba', 'S7ack'),
+(2, 'fa0440b2-f1d4-4f1b-a08f-65e8cd1c65b3', 'Starbucks'),
+(3, 'c6c8f75f-543e-46da-bd02-c564c7005d31', 'Digitec');
 
 -- --------------------------------------------------------
 
@@ -58,9 +60,16 @@ CREATE TABLE `badge_entity` (
 --
 
 INSERT INTO `badge_entity` (`id`, `description`, `name`, `application_entity_id`) VALUES
-(1, 'Lorem ipsum description', 'Champion', 1),
-(2, 'Lorem ipsum description 2', 'Génie', 1),
-(3, 'Lorem ipsum description 3', 'Boss', 1);
+(1, 'Vous avez posté votre premier commentaire', 'First', 1),
+(2, 'Vous avez posé votre première question', 'Besoin d\'aide', 1),
+(3, 'Vous avez posé votre 10ème question', 'Novice', 1),
+(4, 'Vous avez posé votre 100ème question', 'Amateur', 1),
+(5, 'Vous avez donné votre 10ème réponse', 'Expérimenté', 1),
+(6, 'Vous avez donné votre 50ème réponse', 'Expert', 1),
+(7, 'Vous avez donné votre 100ème réponse', 'Connaisseur', 1),
+(8, 'Vous avez donné votre 10ème commentaire', 'Fanboy', 1),
+(9, 'Vous avez donné votre 100ème commentaire', 'Communautariste', 1),
+(10, 'Vous avez donné votre 500ème réponse', 'Einstein', 1);
 
 -- --------------------------------------------------------
 
@@ -75,6 +84,17 @@ CREATE TABLE `badge_reward_entity` (
   `user_entity_id` bigint DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
+--
+-- Dumping data for table `badge_reward_entity`
+--
+
+INSERT INTO `badge_reward_entity` (`id`, `timestamp`, `badge_entity_id`, `user_entity_id`) VALUES
+(1, '2021-01-16 17:14:06.090086', 1, 1),
+(2, '2021-01-16 17:14:21.645486', 2, 1),
+(3, '2021-01-16 17:14:22.873986', 3, 1),
+(4, '2021-01-16 17:14:24.035258', 4, 1),
+(5, '2021-01-16 17:14:27.331648', 5, 1);
+
 -- --------------------------------------------------------
 
 --
@@ -83,9 +103,9 @@ CREATE TABLE `badge_reward_entity` (
 
 CREATE TABLE `event_entity` (
   `id` bigint NOT NULL,
+  `app_user_id` varchar(255) DEFAULT NULL,
   `event_type` varchar(255) DEFAULT NULL,
   `timestamp` datetime(6) DEFAULT NULL,
-  `user_id` varchar(255) DEFAULT NULL,
   `application_entity_id` bigint DEFAULT NULL,
   `badge_entity_id` bigint DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
@@ -103,6 +123,17 @@ CREATE TABLE `point_reward_entity` (
   `point_scale_entity_id` bigint DEFAULT NULL,
   `user_entity_id` bigint DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Dumping data for table `point_reward_entity`
+--
+
+INSERT INTO `point_reward_entity` (`id`, `points`, `timestamp`, `point_scale_entity_id`, `user_entity_id`) VALUES
+(1, 1, '2021-01-16 17:14:06.064469', 3, 1),
+(2, 1, '2021-01-16 17:14:21.621051', 1, 1),
+(3, 1, '2021-01-16 17:14:22.858943', 1, 1),
+(4, 10, '2021-01-16 17:14:24.014577', 1, 1),
+(5, 1, '2021-01-16 17:14:27.316686', 2, 1);
 
 -- --------------------------------------------------------
 
@@ -122,8 +153,9 @@ CREATE TABLE `point_scale_entity` (
 --
 
 INSERT INTO `point_scale_entity` (`id`, `description`, `name`, `application_entity_id`) VALUES
-(1, 'Echelle de points pour les questions', 'QuestionPS', 1),
-(2, 'Echelle de points pour les réponses', 'AnswerPS', 1);
+(1, 'Echelle de points pour les questions', 'Questions', 1),
+(2, 'Echelle de points pour les réponses', 'Réponses', 1),
+(3, 'Echelle de points pour les commentaires', 'Commentaires', 1);
 
 -- --------------------------------------------------------
 
@@ -134,24 +166,29 @@ INSERT INTO `point_scale_entity` (`id`, `description`, `name`, `application_enti
 CREATE TABLE `rule_entity` (
   `id` bigint NOT NULL,
   `amount` int NOT NULL,
+  `amount_to_get` int NOT NULL,
   `award_badge` varchar(255) DEFAULT NULL,
   `award_points` varchar(255) DEFAULT NULL,
   `event_type` varchar(255) DEFAULT NULL,
   `name` varchar(255) DEFAULT NULL,
-  `application_entity_id` bigint DEFAULT NULL,
-  `amount_to_get` int NOT NULL
+  `application_entity_id` bigint DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 --
 -- Dumping data for table `rule_entity`
 --
 
-INSERT INTO `rule_entity` (`id`, `amount`, `award_badge`, `award_points`, `event_type`, `name`, `application_entity_id`, `amount_to_get`) VALUES
-(1, 10, 'Champion', 'questionPS', 'question', 'question palier 1', 1, 100),
-(2, 50, 'Génie', 'questionPS', 'question', 'question palier 2', 1, 1000),
-(3, 100, 'Boss', 'questionPS', 'question', 'question palier 3', 1, 10000),
-(4, 5, 'Champion', 'answerPS', 'answer', 'answer palier 1', 1, 50),
-(5, 10, 'Génie', 'answerPS', 'answer', 'answer palier 2', 1, 300);
+INSERT INTO `rule_entity` (`id`, `amount`, `amount_to_get`, `award_badge`, `award_points`, `event_type`, `name`, `application_entity_id`) VALUES
+(1, 1, 10, 'Novice', 'Questions', 'question', '10ème question', 1),
+(2, 10, 100, 'Amateur', 'Questions', 'question', '100ème question', 1),
+(3, 1, 10, 'Fanboy', 'Commentaires', 'comment', '10ème commentaire', 1),
+(4, 10, 100, 'Communautariste', 'Commentaires', 'comment', '100ème commentaire', 1),
+(5, 1, 1, 'First', 'Commentaires', 'comment', '1er commentaire', 1),
+(6, 1, 1, 'Besoin d\'aide', 'Questions', 'question', '1ère question', 1),
+(7, 1, 10, 'Expérimenté', 'Réponses', 'answer', '10ème réponse', 1),
+(8, 10, 50, 'Expert', 'Réponses', 'answer', '50ème réponse', 1),
+(9, 10, 100, 'Connaisseur', 'Réponses', 'answer', '100ème réponse', 1),
+(10, 25, 500, 'Einstein', 'Réponses', 'answer', '500ème réponse', 1);
 
 -- --------------------------------------------------------
 
@@ -165,6 +202,13 @@ CREATE TABLE `user_entity` (
   `nb_badges` int NOT NULL,
   `application_id` bigint NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Dumping data for table `user_entity`
+--
+
+INSERT INTO `user_entity` (`id`, `app_user_id`, `nb_badges`, `application_id`) VALUES
+(1, 'c53ed5d3-1efd-409f-a139-8d3bdef43c96', 5, 1);
 
 --
 -- Indexes for dumped tables
@@ -236,19 +280,19 @@ ALTER TABLE `user_entity`
 -- AUTO_INCREMENT for table `application_entity`
 --
 ALTER TABLE `application_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
 
 --
 -- AUTO_INCREMENT for table `badge_entity`
 --
 ALTER TABLE `badge_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=11;
 
 --
 -- AUTO_INCREMENT for table `badge_reward_entity`
 --
 ALTER TABLE `badge_reward_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
 -- AUTO_INCREMENT for table `event_entity`
@@ -260,25 +304,25 @@ ALTER TABLE `event_entity`
 -- AUTO_INCREMENT for table `point_reward_entity`
 --
 ALTER TABLE `point_reward_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
 -- AUTO_INCREMENT for table `point_scale_entity`
 --
 ALTER TABLE `point_scale_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
 
 --
 -- AUTO_INCREMENT for table `rule_entity`
 --
 ALTER TABLE `rule_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=11;
 
 --
 -- AUTO_INCREMENT for table `user_entity`
 --
 ALTER TABLE `user_entity`
-  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
 --
 -- Constraints for dumped tables

--- a/docker/init/db/gamification-dump-amt-db.sql
+++ b/docker/init/db/gamification-dump-amt-db.sql
@@ -1,0 +1,335 @@
+-- phpMyAdmin SQL Dump
+-- version 5.0.4
+-- https://www.phpmyadmin.net/
+--
+-- Host: impl_db
+-- Generation Time: Jan 08, 2021 at 03:24 PM
+-- Server version: 8.0.22
+-- PHP Version: 7.4.11
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `amt-db`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `application_entity`
+--
+
+CREATE TABLE `application_entity` (
+  `id` bigint NOT NULL,
+  `api_key` varchar(255) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Dumping data for table `application_entity`
+--
+
+INSERT INTO `application_entity` (`id`, `api_key`, `name`) VALUES
+(1, 'eca8983f-c4c9-4093-a975-0a2178e130ef', 'Stack');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `badge_entity`
+--
+
+CREATE TABLE `badge_entity` (
+  `id` bigint NOT NULL,
+  `description` varchar(255) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `application_entity_id` bigint DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Dumping data for table `badge_entity`
+--
+
+INSERT INTO `badge_entity` (`id`, `description`, `name`, `application_entity_id`) VALUES
+(1, 'Lorem ipsum description', 'Champion', 1),
+(2, 'Lorem ipsum description 2', 'Génie', 1),
+(3, 'Lorem ipsum description 3', 'Boss', 1);
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `badge_reward_entity`
+--
+
+CREATE TABLE `badge_reward_entity` (
+  `id` bigint NOT NULL,
+  `timestamp` datetime(6) DEFAULT NULL,
+  `badge_entity_id` bigint DEFAULT NULL,
+  `user_entity_id` bigint DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `event_entity`
+--
+
+CREATE TABLE `event_entity` (
+  `id` bigint NOT NULL,
+  `event_type` varchar(255) DEFAULT NULL,
+  `timestamp` datetime(6) DEFAULT NULL,
+  `user_id` varchar(255) DEFAULT NULL,
+  `application_entity_id` bigint DEFAULT NULL,
+  `badge_entity_id` bigint DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `point_reward_entity`
+--
+
+CREATE TABLE `point_reward_entity` (
+  `id` bigint NOT NULL,
+  `points` int NOT NULL,
+  `timestamp` datetime(6) DEFAULT NULL,
+  `point_scale_entity_id` bigint DEFAULT NULL,
+  `user_entity_id` bigint DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `point_scale_entity`
+--
+
+CREATE TABLE `point_scale_entity` (
+  `id` bigint NOT NULL,
+  `description` varchar(255) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `application_entity_id` bigint DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Dumping data for table `point_scale_entity`
+--
+
+INSERT INTO `point_scale_entity` (`id`, `description`, `name`, `application_entity_id`) VALUES
+(1, 'Echelle de points pour les questions', 'QuestionPS', 1),
+(2, 'Echelle de points pour les réponses', 'AnswerPS', 1);
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `rule_entity`
+--
+
+CREATE TABLE `rule_entity` (
+  `id` bigint NOT NULL,
+  `amount` int NOT NULL,
+  `award_badge` varchar(255) DEFAULT NULL,
+  `award_points` varchar(255) DEFAULT NULL,
+  `event_type` varchar(255) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `application_entity_id` bigint DEFAULT NULL,
+  `amount_to_get` int NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Dumping data for table `rule_entity`
+--
+
+INSERT INTO `rule_entity` (`id`, `amount`, `award_badge`, `award_points`, `event_type`, `name`, `application_entity_id`, `amount_to_get`) VALUES
+(1, 10, 'Champion', 'questionPS', 'question', 'question palier 1', 1, 100),
+(2, 50, 'Génie', 'questionPS', 'question', 'question palier 2', 1, 1000),
+(3, 100, 'Boss', 'questionPS', 'question', 'question palier 3', 1, 10000),
+(4, 5, 'Champion', 'answerPS', 'answer', 'answer palier 1', 1, 50),
+(5, 10, 'Génie', 'answerPS', 'answer', 'answer palier 2', 1, 300);
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `user_entity`
+--
+
+CREATE TABLE `user_entity` (
+  `id` bigint NOT NULL,
+  `app_user_id` varchar(255) DEFAULT NULL,
+  `nb_badges` int NOT NULL,
+  `application_id` bigint NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `application_entity`
+--
+ALTER TABLE `application_entity`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- Indexes for table `badge_entity`
+--
+ALTER TABLE `badge_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FK4bxv5g78uhxtg32o1u0322hs3` (`application_entity_id`);
+
+--
+-- Indexes for table `badge_reward_entity`
+--
+ALTER TABLE `badge_reward_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FK19fgra7vmd5c8exmlfbe5ijau` (`badge_entity_id`),
+  ADD KEY `FKnu9y7amob1yeqgqprcmib8y6h` (`user_entity_id`);
+
+--
+-- Indexes for table `event_entity`
+--
+ALTER TABLE `event_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FKhhr0yo3gw9rjom16a2nq9eypb` (`application_entity_id`),
+  ADD KEY `FKagmilatu4g1nqfbeo8wgg6pm5` (`badge_entity_id`);
+
+--
+-- Indexes for table `point_reward_entity`
+--
+ALTER TABLE `point_reward_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FKdscpu50ix3xnno9w2tcvs7q5o` (`point_scale_entity_id`),
+  ADD KEY `FK926i3b3j0prankl74d94a4gem` (`user_entity_id`);
+
+--
+-- Indexes for table `point_scale_entity`
+--
+ALTER TABLE `point_scale_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FK686rlx2ie95f1t1o17f5mre99` (`application_entity_id`);
+
+--
+-- Indexes for table `rule_entity`
+--
+ALTER TABLE `rule_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FKnn89qg126y4mq4uoswcrm00e0` (`application_entity_id`);
+
+--
+-- Indexes for table `user_entity`
+--
+ALTER TABLE `user_entity`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `FK79i1v8q1oo1pxma2e58w6dv87` (`application_id`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `application_entity`
+--
+ALTER TABLE `application_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+
+--
+-- AUTO_INCREMENT for table `badge_entity`
+--
+ALTER TABLE `badge_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
+
+--
+-- AUTO_INCREMENT for table `badge_reward_entity`
+--
+ALTER TABLE `badge_reward_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `event_entity`
+--
+ALTER TABLE `event_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `point_reward_entity`
+--
+ALTER TABLE `point_reward_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `point_scale_entity`
+--
+ALTER TABLE `point_scale_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+
+--
+-- AUTO_INCREMENT for table `rule_entity`
+--
+ALTER TABLE `rule_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+
+--
+-- AUTO_INCREMENT for table `user_entity`
+--
+ALTER TABLE `user_entity`
+  MODIFY `id` bigint NOT NULL AUTO_INCREMENT;
+
+--
+-- Constraints for dumped tables
+--
+
+--
+-- Constraints for table `badge_entity`
+--
+ALTER TABLE `badge_entity`
+  ADD CONSTRAINT `FK4bxv5g78uhxtg32o1u0322hs3` FOREIGN KEY (`application_entity_id`) REFERENCES `application_entity` (`id`);
+
+--
+-- Constraints for table `badge_reward_entity`
+--
+ALTER TABLE `badge_reward_entity`
+  ADD CONSTRAINT `FK19fgra7vmd5c8exmlfbe5ijau` FOREIGN KEY (`badge_entity_id`) REFERENCES `badge_entity` (`id`),
+  ADD CONSTRAINT `FKnu9y7amob1yeqgqprcmib8y6h` FOREIGN KEY (`user_entity_id`) REFERENCES `user_entity` (`id`);
+
+--
+-- Constraints for table `event_entity`
+--
+ALTER TABLE `event_entity`
+  ADD CONSTRAINT `FKagmilatu4g1nqfbeo8wgg6pm5` FOREIGN KEY (`badge_entity_id`) REFERENCES `badge_entity` (`id`),
+  ADD CONSTRAINT `FKhhr0yo3gw9rjom16a2nq9eypb` FOREIGN KEY (`application_entity_id`) REFERENCES `application_entity` (`id`);
+
+--
+-- Constraints for table `point_reward_entity`
+--
+ALTER TABLE `point_reward_entity`
+  ADD CONSTRAINT `FK926i3b3j0prankl74d94a4gem` FOREIGN KEY (`user_entity_id`) REFERENCES `user_entity` (`id`),
+  ADD CONSTRAINT `FKdscpu50ix3xnno9w2tcvs7q5o` FOREIGN KEY (`point_scale_entity_id`) REFERENCES `point_scale_entity` (`id`);
+
+--
+-- Constraints for table `point_scale_entity`
+--
+ALTER TABLE `point_scale_entity`
+  ADD CONSTRAINT `FK686rlx2ie95f1t1o17f5mre99` FOREIGN KEY (`application_entity_id`) REFERENCES `application_entity` (`id`);
+
+--
+-- Constraints for table `rule_entity`
+--
+ALTER TABLE `rule_entity`
+  ADD CONSTRAINT `FKnn89qg126y4mq4uoswcrm00e0` FOREIGN KEY (`application_entity_id`) REFERENCES `application_entity` (`id`);
+
+--
+-- Constraints for table `user_entity`
+--
+ALTER TABLE `user_entity`
+  ADD CONSTRAINT `FK79i1v8q1oo1pxma2e58w6dv87` FOREIGN KEY (`application_id`) REFERENCES `application_entity` (`id`);
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/api/endpoints/EventsApiController.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/api/endpoints/EventsApiController.java
@@ -2,7 +2,6 @@ package ch.heigvd.amt.gamification.api.endpoints;
 
 import ch.heigvd.amt.gamification.api.EventsApi;
 import ch.heigvd.amt.gamification.api.model.Event;
-import ch.heigvd.amt.gamification.api.model.EventProperties;
 import ch.heigvd.amt.gamification.entities.ApplicationEntity;
 import ch.heigvd.amt.gamification.entities.EventEntity;
 import ch.heigvd.amt.gamification.services.EventProcessorService;
@@ -51,8 +50,6 @@ public class EventsApiController implements EventsApi {
         entity.setAppUserId(event.getAppUserId());
         entity.setTimestamp(event.getTimestamp());
         entity.setEventType(event.getEventType());
-        entity.setSubType(event.getProperties().getSubType());
-        entity.setQuantity(event.getProperties().getQuantity());
         return entity;
     }
 
@@ -61,12 +58,6 @@ public class EventsApiController implements EventsApi {
         event.setAppUserId(entity.getAppUserId());
         event.setTimestamp(entity.getTimestamp());
         event.setEventType(entity.getEventType());
-
-        EventProperties eventProperties = new EventProperties();
-        eventProperties.setSubType(entity.getSubType());
-        eventProperties.setQuantity(entity.getQuantity());
-        event.setProperties(eventProperties);
-
         return event;
     }
 }

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/api/endpoints/RulesApiController.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/api/endpoints/RulesApiController.java
@@ -31,12 +31,10 @@ public class RulesApiController implements RulesApi {
     public ResponseEntity<Void> createRule(@ApiParam(value = "", required = true) @Valid @RequestBody Rule rule) {
         //Controle avec quelle event la pointScale est liée
         List<RuleEntity> doesPointScaleExist = ruleRepository.findAllByAwardPoints(rule.getThen().getAwardPoints().getPointScale());
-        System.out.println("doesPointScaleExist " + doesPointScaleExist);
         List<RuleEntity> rulesEventTypePS = null;
         if(doesPointScaleExist != null){
              rulesEventTypePS = ruleRepository.findAllByAwardPointsAndEventType(rule.getThen().getAwardPoints().getPointScale(), rule.getIf().getEventType());
         }
-        System.out.println("rulesEventTypePS " + rulesEventTypePS);
 
         //Lie la pointScale avec l'eventType la première fois qu'on crée la règle avec
         boolean isPointScaleAlreadyUsed = false;
@@ -44,15 +42,13 @@ public class RulesApiController implements RulesApi {
             isPointScaleAlreadyUsed =  rulesEventTypePS != null && rulesEventTypePS.size() == 0;
         }
 
-        System.out.println("isPointScaleAlreadyUsed " + isPointScaleAlreadyUsed);
-
         // Controle si le pallier est bien unique pour la pointScale
         RuleEntity ruleStepPS = ruleRepository.findByAmountToGetAndAwardPoints(rule.getThen().getAwardPoints().getAmountToGet(), rule.getThen().getAwardPoints().getPointScale());
 
         if(isPointScaleAlreadyUsed
                 || ruleStepPS != null
                 || rule.getThen().getAwardPoints().getAmount() < 0 || rule.getThen().getAwardPoints().getAmount() > rule.getThen().getAwardPoints().getAmountToGet()
-                || rule.getThen().getAwardPoints().getAmountToGet() == 0
+                || rule.getThen().getAwardPoints().getAmountToGet() == 0 || rule.getThen().getAwardPoints().getAmount() == 0
                 || rule.getThen().getAwardPoints().getAmountToGet() % rule.getThen().getAwardPoints().getAmount() != 0){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/api/endpoints/RulesApiController.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/api/endpoints/RulesApiController.java
@@ -29,7 +29,7 @@ public class RulesApiController implements RulesApi {
 
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createRule(@ApiParam(value = "", required = true) @Valid @RequestBody Rule rule) {
-        //Controle avec quelle event la pointscale est lié
+        //Controle avec quelle event la pointScale est liée
         List<RuleEntity> doesPointScaleExist = ruleRepository.findAllByAwardPoints(rule.getThen().getAwardPoints().getPointScale());
         System.out.println("doesPointScaleExist " + doesPointScaleExist);
         List<RuleEntity> rulesEventTypePS = null;
@@ -38,7 +38,7 @@ public class RulesApiController implements RulesApi {
         }
         System.out.println("rulesEventTypePS " + rulesEventTypePS);
 
-        //Lie le pointScale avec l'eventType la première fois qu'on crée la règle avec
+        //Lie la pointScale avec l'eventType la première fois qu'on crée la règle avec
         boolean isPointScaleAlreadyUsed = false;
         if(doesPointScaleExist != null && doesPointScaleExist.size() !=0){
             isPointScaleAlreadyUsed =  rulesEventTypePS != null && rulesEventTypePS.size() == 0;
@@ -46,7 +46,7 @@ public class RulesApiController implements RulesApi {
 
         System.out.println("isPointScaleAlreadyUsed " + isPointScaleAlreadyUsed);
 
-        // Controle si le pallier est bien unique pour le pointscale
+        // Controle si le pallier est bien unique pour la pointScale
         RuleEntity ruleStepPS = ruleRepository.findByAmountToGetAndAwardPoints(rule.getThen().getAwardPoints().getAmountToGet(), rule.getThen().getAwardPoints().getPointScale());
 
         if(isPointScaleAlreadyUsed

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/entities/EventEntity.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/entities/EventEntity.java
@@ -17,8 +17,6 @@ public class EventEntity implements Serializable {
     private String appUserId;
     private OffsetDateTime timestamp;
     private String eventType;
-    private String subType;
-    private int quantity;
 
     @ManyToOne
     private BadgeEntity badgeEntity;

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/repositories/RuleRepository.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/repositories/RuleRepository.java
@@ -10,4 +10,9 @@ import java.util.List;
 public interface RuleRepository extends CrudRepository<RuleEntity, Long> {
     List<RuleEntity> findAllByApplicationEntity(ApplicationEntity applicationEntity);
     List<RuleEntity> findAllByApplicationEntityAndEventTypeOrderByAmountToGetAsc(ApplicationEntity applicationEntity, String eventType);
+    RuleEntity findByAmountToGetAndAwardPoints(int amountToGet, String pointScale);
+
+    List<RuleEntity> findAllByAwardPoints(String pointScale);
+    List<RuleEntity> findAllByAwardPointsAndEventType(String pointScale, String eventType);
+
 }

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
@@ -48,45 +48,44 @@ public class EventProcessorService {
         List<RuleEntity> eventRulesOfType = ruleRepository.findAllByApplicationEntityAndEventTypeOrderByAmountToGetAsc(applicationEntity, eventEntity.getEventType());
         RuleEntity ruletoApply = null;
         BadgeEntity badgeEntityOfApp = null;
-        BadgeRewardEntity isPossessed = null;
+
+        int userPoints = 0;
         for(RuleEntity ruleOfType : eventRulesOfType) {
              ruletoApply = ruleOfType;
+             PointScaleEntity pointScaleEntityOfApp = pointScaleRepository.findByApplicationEntityAndName(applicationEntity, ruletoApply.getAwardPoints());
              badgeEntityOfApp = badgeRepository.findByApplicationEntityAndName(applicationEntity, ruleOfType.getAwardBadge());
              System.out.println(ruleOfType.getAwardBadge());
 
-             isPossessed = badgeRewardRepository.findByBadgeEntityAndUserEntity(badgeEntityOfApp, user);
-
-             if(badgeEntityOfApp != null && isPossessed == null){
-                 break;
-             }
-        }
-
-        // Si on a déjà obtenu tous les badges de chaque palier ou qu'il n'y a pas de règle à appliquer
-        if(isPossessed != null || ruletoApply == null){
-            return user.getId();
-        }
-
-            PointScaleEntity pointScaleEntityOfApp = pointScaleRepository.findByApplicationEntityAndName(applicationEntity, ruletoApply.getAwardPoints());
-            int userPoints = 0;
-
             // Attribuer des points si la Rule l'indique
             if(pointScaleEntityOfApp != null) {
+                userPoints = 0;
                 // La règle attribue des points à l'utilisateur sur la pointScale définie
                 PointRewardEntity pointRewardEntity = new PointRewardEntity();
                 pointRewardEntity.setPointScaleEntity(pointScaleEntityOfApp);
                 pointRewardEntity.setUserEntity(user);
                 pointRewardEntity.setTimestamp(LocalDateTime.now());
                 pointRewardEntity.setPoints(ruletoApply.getAmount());
-                pointRewardRepository.save(pointRewardEntity);
 
                 List<PointRewardEntity> userPointRewardEntityList = pointRewardRepository.findAllByUserEntityAndPointScaleEntity(user, pointScaleEntityOfApp);
-                for(PointRewardEntity userPointRewardEntity : userPointRewardEntityList) {
+                for (PointRewardEntity userPointRewardEntity : userPointRewardEntityList) {
                     userPoints += userPointRewardEntity.getPoints();
                 }
-            }
 
-            // Attribue un badge si la Rule l'indique
-            if(badgeEntityOfApp != null) {
+                if (userPoints < ruletoApply.getAmountToGet()) {
+                    pointRewardRepository.save(pointRewardEntity);
+                    break;
+                }
+
+            }
+        }
+
+        // Si on a déjà obtenu tous les badges de chaque palier ou qu'il n'y a pas de règle à appliquer
+        //if(isPossessed != null || ruletoApply == null){
+        //    return user.getId();
+        //}
+
+            // Attribue un badge si la Rule l'indique et si on le bon nombre de points
+            if(badgeEntityOfApp != null && userPoints >= ruletoApply.getAmountToGet()) {
                 // La règle attribue un badge à l'utilisateur
                 BadgeRewardEntity badgeRewardEntity = new BadgeRewardEntity();
                 badgeRewardEntity.setBadgeEntity(badgeEntityOfApp);

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
@@ -55,7 +55,6 @@ public class EventProcessorService {
              ruletoApply = ruleOfType;
              PointScaleEntity pointScaleEntityOfApp = pointScaleRepository.findByApplicationEntityAndName(applicationEntity, ruletoApply.getAwardPoints());
              badgeEntityOfApp = badgeRepository.findByApplicationEntityAndName(applicationEntity, ruleOfType.getAwardBadge());
-             System.out.println(ruleOfType.getAwardBadge());
 
             // Attribuer des points si la Rule l'indique
             if(pointScaleEntityOfApp != null) {

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
@@ -5,12 +5,10 @@ import ch.heigvd.amt.gamification.repositories.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.Console;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 @Service
 public class EventProcessorService {
@@ -78,23 +76,24 @@ public class EventProcessorService {
                     pointRewardRepository.save(pointRewardEntity);
                     pointscales.add(ruletoApply.getAwardPoints());
                 }
+
+                // Attribue un badge si on a pas atteint la fin du pallier, si la Rule l'indique et si on le bon nombre de points
+                if(pointscales.contains(ruletoApply.getAwardPoints()) && badgeEntityOfApp != null && userPoints + ruleOfType.getAmount() >= ruletoApply.getAmountToGet()) {
+                    // La règle attribue un badge à l'utilisateur
+                    BadgeRewardEntity badgeRewardEntity = new BadgeRewardEntity();
+                    badgeRewardEntity.setBadgeEntity(badgeEntityOfApp);
+                    badgeRewardEntity.setUserEntity(user);
+                    badgeRewardEntity.setTimestamp(LocalDateTime.now());
+                    badgeRewardRepository.save(badgeRewardEntity);
+
+                    // Incrémente le compteur de badges de l'utilisateur
+                    int nbBadges = user.getNbBadges();
+                    user.setNbBadges(++nbBadges);
+                    userRepository.save(user);
+                }
             }
         }
 
-            // Attribue un badge si la Rule l'indique et si on le bon nombre de points
-            if(badgeEntityOfApp != null && userPoints >= ruletoApply.getAmountToGet()) {
-                // La règle attribue un badge à l'utilisateur
-                BadgeRewardEntity badgeRewardEntity = new BadgeRewardEntity();
-                badgeRewardEntity.setBadgeEntity(badgeEntityOfApp);
-                badgeRewardEntity.setUserEntity(user);
-                badgeRewardEntity.setTimestamp(LocalDateTime.now());
-                badgeRewardRepository.save(badgeRewardEntity);
-
-                // Incrémente le compteur de badges de l'utilisateur
-                int nbBadges = user.getNbBadges();
-                user.setNbBadges(++nbBadges);
-                userRepository.save(user);
-            }
         return user.getId();
     }
 }

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
@@ -7,7 +7,10 @@ import org.springframework.stereotype.Service;
 
 import java.io.Console;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 @Service
 public class EventProcessorService {
@@ -48,8 +51,8 @@ public class EventProcessorService {
         List<RuleEntity> eventRulesOfType = ruleRepository.findAllByApplicationEntityAndEventTypeOrderByAmountToGetAsc(applicationEntity, eventEntity.getEventType());
         RuleEntity ruletoApply = null;
         BadgeEntity badgeEntityOfApp = null;
-
         int userPoints = 0;
+        Set<String> pointscales = new HashSet<>();
         for(RuleEntity ruleOfType : eventRulesOfType) {
              ruletoApply = ruleOfType;
              PointScaleEntity pointScaleEntityOfApp = pointScaleRepository.findByApplicationEntityAndName(applicationEntity, ruletoApply.getAwardPoints());
@@ -71,18 +74,12 @@ public class EventProcessorService {
                     userPoints += userPointRewardEntity.getPoints();
                 }
 
-                if (userPoints < ruletoApply.getAmountToGet()) {
+                if (!pointscales.contains(ruletoApply.getAwardPoints()) && userPoints + ruleOfType.getAmount() <= ruletoApply.getAmountToGet()) {
                     pointRewardRepository.save(pointRewardEntity);
-                    break;
+                    pointscales.add(ruletoApply.getAwardPoints());
                 }
-
             }
         }
-
-        // Si on a déjà obtenu tous les badges de chaque palier ou qu'il n'y a pas de règle à appliquer
-        //if(isPossessed != null || ruletoApply == null){
-        //    return user.getId();
-        //}
 
             // Attribue un badge si la Rule l'indique et si on le bon nombre de points
             if(badgeEntityOfApp != null && userPoints >= ruletoApply.getAmountToGet()) {

--- a/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
+++ b/gamification-impl/src/main/java/ch/heigvd/amt/gamification/services/EventProcessorService.java
@@ -77,7 +77,7 @@ public class EventProcessorService {
                     pointscales.add(ruletoApply.getAwardPoints());
                 }
 
-                // Attribue un badge si on a pas atteint la fin du pallier, si la Rule l'indique et si on le bon nombre de points
+                // Attribue un badge si on a pas atteint la fin du pallier, si la Rule l'indique et si on a le bon nombre de points
                 if(pointscales.contains(ruletoApply.getAwardPoints()) && badgeEntityOfApp != null && userPoints + ruleOfType.getAmount() >= ruletoApply.getAmountToGet()) {
                     // La règle attribue un badge à l'utilisateur
                     BadgeRewardEntity badgeRewardEntity = new BadgeRewardEntity();

--- a/gamification-impl/src/main/resources/api-spec.yaml
+++ b/gamification-impl/src/main/resources/api-spec.yaml
@@ -277,13 +277,6 @@ components:
           format: date-time
         eventType:
           type: string
-        properties:
-          type: object
-          properties:
-            subType:
-              type: string
-            quantity:
-              type: integer
     User:
       type: object
       properties:

--- a/gamification-specs/src/main/resources/api-spec.yaml
+++ b/gamification-specs/src/main/resources/api-spec.yaml
@@ -277,13 +277,6 @@ components:
           format: date-time
         eventType:
           type: string
-        properties:
-          type: object
-          properties:
-            subType:
-              type: string
-            quantity:
-              type: integer
     User:
       type: object
       properties:

--- a/gamification-specs/src/test/java/ch/heigvd/amt/gamification/api/spec/steps/EventsSteps.java
+++ b/gamification-specs/src/test/java/ch/heigvd/amt/gamification/api/spec/steps/EventsSteps.java
@@ -4,7 +4,6 @@ import ch.heigvd.amt.gamification.ApiException;
 import ch.heigvd.amt.gamification.ApiResponse;
 import ch.heigvd.amt.gamification.api.DefaultApi;
 import ch.heigvd.amt.gamification.api.dto.Event;
-import ch.heigvd.amt.gamification.api.dto.EventProperties;
 import ch.heigvd.amt.gamification.api.spec.helpers.Environment;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
@@ -32,14 +31,11 @@ public class EventsSteps {
 
     @Given("I have an event payload")
     public void i_have_an_event_payload() {
-        EventProperties eventProperties = new EventProperties()
-                .quantity(0)
-                .subType("mockPropertyType");
 
-        event = new Event().properties(eventProperties)
-                //.timestamp();
-                .eventType("mockType")
-                .appUserId("mockUserIs");
+        event = new Event()
+            //.timestamp();
+            .eventType("mockType")
+            .appUserId("mockUserIs");
     }
 
     @When("I POST the event payload to the \\/events endpoint")
@@ -47,7 +43,7 @@ public class EventsSteps {
         try {
             lastApiResponse = api.createEventWithHttpInfo(event);
             environment.processApiResponse(lastApiResponse);
-        } catch (ApiException e) {
+        } catch(ApiException e) {
             environment.processApiException(e);
         }
     }

--- a/gamification-specs/src/test/java/ch/heigvd/amt/gamification/api/spec/steps/UsersSteps.java
+++ b/gamification-specs/src/test/java/ch/heigvd/amt/gamification/api/spec/steps/UsersSteps.java
@@ -4,7 +4,6 @@ import ch.heigvd.amt.gamification.ApiException;
 import ch.heigvd.amt.gamification.ApiResponse;
 import ch.heigvd.amt.gamification.api.DefaultApi;
 import ch.heigvd.amt.gamification.api.dto.Event;
-import ch.heigvd.amt.gamification.api.dto.EventProperties;
 import ch.heigvd.amt.gamification.api.dto.User;
 import ch.heigvd.amt.gamification.api.spec.helpers.Environment;
 import io.cucumber.java.en.Given;
@@ -42,14 +41,11 @@ public class UsersSteps {
 
     @Given("I have an event payload for user {string}")
     public void i_have_an_event_payload_for_user(String userId) {
-        EventProperties eventProperties = new EventProperties()
-                .quantity(0)
-                .subType("mockPropertyType");
 
-        event = new Event().properties(eventProperties)
-                //.timestamp();
-                .eventType("mockType")
-                .appUserId(userId);
+        event = new Event()
+            //.timestamp();
+            .eventType("mockType")
+            .appUserId(userId);
 
         user = new User().appUserId(userId);
     }
@@ -60,7 +56,7 @@ public class UsersSteps {
         try {
             lastApiResponse = api.createEventWithHttpInfo(event);
             environment.processApiResponse(lastApiResponse);
-        } catch (ApiException e) {
+        } catch(ApiException e) {
             environment.processApiException(e);
         }
     }
@@ -71,7 +67,7 @@ public class UsersSteps {
         try {
             lastApiResponse = api.getUsersWithHttpInfo();
             environment.processApiResponse(lastApiResponse);
-        } catch (ApiException e) {
+        } catch(ApiException e) {
             environment.processApiException(e);
         }
     }
@@ -90,7 +86,7 @@ public class UsersSteps {
             lastApiResponse = api.getUserWithHttpInfo(id);
             environment.processApiResponse(lastApiResponse);
             lastReceivedUser = (User) lastApiResponse.getData();
-        } catch (ApiException e) {
+        } catch(ApiException e) {
             environment.processApiException(e);
         }
     }


### PR DESCRIPTION
Une fois les 2 serveurs (Stack et Gamification API) lancés, on peut utiliser Stack normalement et intéragir avec l'API de gamification.

Pour tester il faut prendre les 2 dernières versions et les lancer dans cet ordre : 
- projet_2 (Gam. API) : `fb-stackintegration`
- projet_1 (Stack) : `72-participation`

J'ai ajouté un SQL dump contenant une clé d'API pour Stack qui est configurée dans le server.env, des Rules pour toutes les entités (question, answer et comment, on oublie les votes, c'est trop compliqué à gérer - upvote/downvote...) et des rewards pour l'utilisateur `test user` qu'on avait définit dans Stack (mais je n'arrive pas à m'y connecter, car les vérifications au login ont été désactivées pour faciliter le dev par @pabloheigvd , il faudra les remettre à la fin du projet)

Lorsque tout est démarré on Register un utilisateur et on peut utiliser l'application normalement, les requêtes POST sont faites à l'API, et les requêtes GET pour récupérer les leaderboards, badges et pointsScores sur les pointScales.

_Images non contractuelles, j'ai copié les pointsScores HTML pour tester le layout/affichage, donc pas de panique si y a 100x le même pointsScore pour les questions :)_

![Screenshot 2021-01-16 at 18 53 12](https://user-images.githubusercontent.com/30025638/104836971-db803400-58b1-11eb-9899-80f9065d22a3.png)
_Leaderboards dans la page Statistics_

![screencapture-localhost-9080-stack-profile-2021-01-16-20_55_46](https://user-images.githubusercontent.com/30025638/104836992-0074a700-58b2-11eb-9bc5-3057ca36db08.png)
_Badges et pointsScores dans le Profile_